### PR TITLE
flatpak plugin: when parsing the manifest check for "id" and "app-id"

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -301,7 +301,6 @@
         },
         {
             "name": "gnome-builder",
-	    "config-opts": [ "--enable-tracing", "--enable-debug" ],
             "sources": [
                 {
                     "type": "git",

--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -301,6 +301,7 @@
         },
         {
             "name": "gnome-builder",
+	    "config-opts": [ "--enable-tracing", "--enable-debug" ],
             "sources": [
                 {
                     "type": "git",

--- a/plugins/flatpak/gbp-flatpak-clone-widget.c
+++ b/plugins/flatpak/gbp-flatpak-clone-widget.c
@@ -471,7 +471,10 @@ get_source (GbpFlatpakCloneWidget  *self,
   root_node = json_parser_get_root (parser);
   root_object = json_node_get_object (root_node);
 
-  self->id = g_strdup (json_object_get_string_member (root_object, "app-id"));
+  if (json_object_has_member (root_object, "app-id"))
+    self->id = g_strdup (json_object_get_string_member (root_object, "app-id"));
+  else if (json_object_has_member (root_object, "id"))
+    self->id = g_strdup (json_object_get_string_member (root_object, "id"));
 
   modules = json_object_get_array_member (root_object, "modules");
   num_modules = json_array_get_length (modules);


### PR DESCRIPTION
The specification allows for "id" and "app-id", and the manifest that comes with the installation has the "id" field set, so we need to support this as well.